### PR TITLE
Convert garfield postpone bins

### DIFF
--- a/wirecell/sigproc/main.py
+++ b/wirecell/sigproc/main.py
@@ -40,11 +40,13 @@ def response_info(ctx, json_file):
               help="Set normalization: 0:none, <0:electrons, >0:multiplicative scale.  def=0")
 @click.option("-z", "--zero-wire-locs", default=[0.0,0.0,0.0], nargs=3, type=float,
               help="Set location of zero wires.  def: 0 0 0")
+@click.option("-d", "--delay", default=0,
+              help="Set additional delay of bins in the output field response.  def=0")
 @click.argument("garfield-fileset")
 @click.argument("wirecell-field-response-file")
 @click.pass_context
 def convert_garfield(ctx, origin, speed, normalization, zero_wire_locs,
-                         garfield_fileset, wirecell_field_response_file):
+                    delay, garfield_fileset, wirecell_field_response_file):
     '''
     Convert an archive of a Garfield fileset (zip, tar, tgz) into a
     Wire Cell field response file (.json with optional .gz or .bz2
@@ -56,7 +58,7 @@ def convert_garfield(ctx, origin, speed, normalization, zero_wire_locs,
 
     origin = eval(origin, units.__dict__)
     speed = eval(speed, units.__dict__)
-    rflist = gar.load(garfield_fileset, normalization, zero_wire_locs)
+    rflist = gar.load(garfield_fileset, normalization, zero_wire_locs, delay)
     fr = res.rf1dtoschema(rflist, origin, speed)
     per.dump(wirecell_field_response_file, fr)
 

--- a/wirecell/sigproc/plots.py
+++ b/wirecell/sigproc/plots.py
@@ -435,8 +435,8 @@ def plot_digitized_line(uvw_rfs,
     xmmymm = list(axes.axis())
 
     # limit time
-    xmmymm[0] = 0.0
-    xmmymm[1] = 50.0
+    xmmymm[0] = 10 # 0.0
+    xmmymm[1] = 15 # 50.0
     #if "dune" in detector.lower():
     #     xmmymm[1] = 25.0
 

--- a/wirecell/sigproc/plots.py
+++ b/wirecell/sigproc/plots.py
@@ -435,10 +435,10 @@ def plot_digitized_line(uvw_rfs,
     xmmymm = list(axes.axis())
 
     # limit time
-    xmmymm[0] = 10 # 0.0
-    xmmymm[1] = 15 # 50.0
-    #if "dune" in detector.lower():
-    #     xmmymm[1] = 25.0
+    xmmymm[0] = 0.0
+    xmmymm[1] = 50.0
+    if "dune" in detector.lower():
+        xmmymm[1] = 25.0
 
     # fixme: this plotter should work on other response functions than Garfield
     # 2D with MB-style 3mm pitch.  This titling is for the MB noise paper.  


### PR DESCRIPTION
Add an integer variable to allow the user to delay the field response when converting the garfield file to the wirecell json format.