### PR TITLE
add warm electronics shaping for icarus

### DIFF
--- a/wirecell/sigproc/main.py
+++ b/wirecell/sigproc/main.py
@@ -40,7 +40,7 @@ def response_info(ctx, json_file):
               help="Set normalization: 0:none, <0:electrons, >0:multiplicative scale.  def=0")
 @click.option("-z", "--zero-wire-locs", default=[0.0,0.0,0.0], nargs=3, type=float,
               help="Set location of zero wires.  def: 0 0 0")
-@click.option("-d", "--delay", default=0,
+@click.option("-d", "--delay", default=0, type=int,
               help="Set additional delay of bins in the output field response.  def=0")
 @click.argument("garfield-fileset")
 @click.argument("wirecell-field-response-file")
@@ -94,6 +94,8 @@ def plot_garfield_exhaustive(ctx, normalization, zero_wire_locs,
                   help="Number of ticks of zero ADC to pre-pad the plots.")
 @click.option("-e", "--electrons", default=13300,
                 help="Set normalization in units of electron charge.")
+@click.option("--elec-type", default="cold", type=str,
+                  help="Set electronics type [cold | warm] (def: cold).")
 @click.option("-a", "--adc-gain", default=1.2,
                   help="Set ADC gain (unitless).")
 @click.option("--adc-voltage", default=2.0,
@@ -116,7 +118,7 @@ def plot_garfield_exhaustive(ctx, normalization, zero_wire_locs,
 @click.argument("pdffile")
 @click.pass_context
 def plot_garfield_track_response(ctx, gain, shaping, tick, tick_padding, electrons,
-                                     adc_gain, adc_voltage, adc_resolution,
+                                     elec_type, adc_gain, adc_voltage, adc_resolution,
                                      normalization, zero_wire_locs,
                                      ymin, ymax, regions,
                                      dump_data,
@@ -161,6 +163,8 @@ def plot_garfield_track_response(ctx, gain, shaping, tick, tick_padding, electro
     msg=""
 
     fig,data = plots.plot_digitized_line(uvw, gain, shaping,
+                                         tick = tick,
+                                         elec_type = elec_type,
                                          adc_per_voltage = adc_per_voltage,
                                          detector = detector,
                                          ymin=ymin, ymax=ymax, msg=msg,
@@ -208,9 +212,11 @@ def plot_response(ctx, responsefile, pdffile):
               help="Set shaping time in us.")
 @click.option("-t", "--tick", default=0.5,
               help="Set tick time in us (0.1 is good for no shaping).")
+@click.option("-e", "--electype", default="cold",
+              help="Set electronics type [cold | warm] (def: cold).")
 @click.argument("plotfile")
 @click.pass_context
-def plot_electronics_response(ctx, gain, shaping, tick, plotfile):
+def plot_electronics_response(ctx, gain, shaping, tick, electype, plotfile):
     '''
     Plot the electronics response function.
     '''
@@ -218,7 +224,7 @@ def plot_electronics_response(ctx, gain, shaping, tick, plotfile):
     shaping *= units.us
     tick *= units.us
     import wirecell.sigproc.plots as plots
-    fig = plots.one_electronics(gain, shaping, tick)
+    fig = plots.one_electronics(gain, shaping, tick, electype)
     fig.savefig(plotfile)
 
 

--- a/wirecell/sigproc/plots.py
+++ b/wirecell/sigproc/plots.py
@@ -68,14 +68,14 @@ def average_shaping(rflist_avg, gain_mVfC=14, shaping=2.0*units.us, nbins=5000):
     
     
 
-def one_electronics(gain, shaping, tick=0.1*units.us):
+def one_electronics(gain, shaping, tick=0.1*units.us, elec_type="cold"):
     '''
     Plot one electronics response function
     '''
     tmax = 10*units.us
     nticks = tmax/tick
     times = numpy.linspace(0, tmax, nticks)
-    res = response.electronics(times, gain, shaping)
+    res = response.electronics(times, gain, shaping, elec_type)
     fig, axes = plt.subplots(1, 1)
 
     x = times/units.us
@@ -352,6 +352,7 @@ def plot_digitized_line(uvw_rfs,
                         gain=14.0*units.mV/units.fC,
                         shaping=2.0*units.us,
                         tick=0.5*units.us,
+                        elec_type="cold",
                         adc_per_voltage = 1.2*4096/(2.0*units.volt),
                         detector = "MicroBooNE",
                         ymin=None, ymax=None, msg="",
@@ -388,7 +389,7 @@ def plot_digitized_line(uvw_rfs,
         print (rf.plane, legends[ind], numpy.sum(rf.response)*dt_hi/units.eplus, " electrons")
 
         if shaping:
-            sig = rf.shaped(gain, shaping)
+            sig = rf.shaped(gain, shaping, elec_type=elec_type)
         else:
             print ('No shaping')
             sig = rf
@@ -437,8 +438,8 @@ def plot_digitized_line(uvw_rfs,
     # limit time
     xmmymm[0] = 0.0
     xmmymm[1] = 50.0
-    if "dune" in detector.lower():
-        xmmymm[1] = 25.0
+    # if "dune" in detector.lower():
+    #     xmmymm[1] = 25.0
 
     # fixme: this plotter should work on other response functions than Garfield
     # 2D with MB-style 3mm pitch.  This titling is for the MB noise paper.  


### PR DESCRIPTION
To draw the total field response for icarus:
```
wirecell-sigproc plot-garfield-track-response --ymax 25 --ymin -25 -e 15000 -t 0.4 -g -17.8075 -s 1.3 --adc-voltage 3.3 --elec-type=warm -a 1 -n -1 -p 20 icarus_fnal_commissioning.tar.gz plot_icarus_garfield_repsonse.png
```