### PR TITLE
update multitpc util for sbnd

### DIFF
--- a/wirecell/util/main.py
+++ b/wirecell/util/main.py
@@ -33,10 +33,12 @@ def convert_oneside_wires(ctx, input_file, output_file):
 
 
 @cli.command("convert-multitpc-wires")
+@click.option('--duoface/--no-duoface', default=True,
+              help="Allow two faces in an anode or not")
 @click.argument("input-file")
 @click.argument("output-file")
 @click.pass_context
-def convert_multitpc_wires(ctx, input_file, output_file):
+def convert_multitpc_wires(ctx, duoface, input_file, output_file):
     '''
     Convert a "multitpc" wire description file into one suitable for
     WCT.
@@ -49,9 +51,12 @@ def convert_multitpc_wires(ctx, input_file, output_file):
 
     And, further the order of rows of identical channel number express
     progressively higher segment count.
+
+    (Optional) if "--no-duoface" is enabled, we enforce each anode
+    to have one face. This function is designed for SBND
     '''
     from wirecell.util.wires import multitpc, persist
-    store = multitpc.load(input_file)
+    store = multitpc.load(input_file, duoface=duoface)
     persist.dump(output_file, store)
 
 @cli.command("convert-icarustpc-wires")

--- a/wirecell/util/wires/multitpc.py
+++ b/wirecell/util/wires/multitpc.py
@@ -12,7 +12,7 @@ import matplotlib.patches as mpatches
 
 from collections import defaultdict, namedtuple
 
-def load(filename):
+def load(filename, duoface):
     '''
     Load a "multitpc" geometry file.
 
@@ -100,9 +100,14 @@ def load(filename):
             if beg[1] > end[1]:
                 beg,end = end,beg # always point upward in Y
 
-            face = (1+tpc)%2    # "front" face is 0.
-            apa = tpc//2        # pure conjecture
-            wid = wire          # this too
+            if duoface: # default
+                face = (1+tpc)%2    # "front" face is 0.
+                apa = tpc//2        # pure conjecture
+                wid = wire          # this too
+            else: # enforce one face
+                face = 0
+                apa = tpc
+                wid = wire
 
             wpid = schema.wire_plane_id(plane, face, apa)
 


### PR DESCRIPTION
SBND has two TPCs while it doesn't have two faces for each anode, So I add an option "--no-duoface" to enforce one face.

Usage:
```
wirecell-util convert-multitpc-wires --no-duoface sbnd-wires-larsoft-v1.txt sbnd-wires-larsoft-v1.json.bz2
```

Both `sbnd-wires-larsoft-v1.txt` and `sbnd-wires-larsoft-v1.json.bz2` have been uploaded to `wire-cell-data`.