### PR TITLE
Expand the "comp1d" plotter and related code

### DIFF
--- a/wirecell/util/ario.py
+++ b/wirecell/util/ario.py
@@ -90,6 +90,7 @@ class Tar(Arf):
         '''
         Create a Tar mapping on file path.  
         '''
+        self.path = path
         mode = "r"
         if path.endswith(('.gz', '.tgz')):
             mode += ':gz'
@@ -144,7 +145,7 @@ class Zip(Arf):
     This will lazy load.
     '''
     def __init__(self, path, lazy=True):
-
+        self.path = path
         zf = zipfile.ZipFile(path)
         self._lazy = lazy
         if lazy:

--- a/wirecell/util/plottools.py
+++ b/wirecell/util/plottools.py
@@ -8,6 +8,7 @@ import numpy as np
 from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
 import numpy
+from pathlib import Path
 
 class NameSequence(object):
     def __init__(self, name, first=0):
@@ -59,6 +60,35 @@ class NameSequence(object):
         return
         
         
+class NameSingleton(object):
+    def __init__(self, path):
+        '''
+        Like a NameSequence but force a singleton.
+
+        No name mangling, and subsequent calls are ignored.
+        '''
+        self.path = Path(path)
+        self.called = 0
+
+    def __call__(self):
+        return self.path
+
+    def savefig(self, *args, **kwds):
+        '''
+        Act like PdfPages
+        '''
+        if self.called == 0:
+            if not self.path.parent.exists():
+                self.path.parent.mkdir(parents=True)
+            plt.savefig(self.path.absolute(), **kwds)
+        self.called += 1
+
+    def __enter__(self):
+        return self
+    def __exit__(self, typ, value, traceback):
+        return
+
+
 def pages(name):
     if name.endswith(".pdf"):
         return PdfPages(name)


### PR DESCRIPTION
- (Breaking) The output file is now given with -o/--output instead of an argument.
- (Breaking) No transformation by default
- Add more ways to "transform" the data (median, mean, ac, none).
- Allow more (or less) than 2 data files to be plotted.
- Add a "single plot" mode that will not munge the output file name.
- Allow explicit list of frame array names as well as "tier" based frame selection.
- Use markers so that plots tend to obscuring others less.